### PR TITLE
Prefer cloud-init generated eni files

### DIFF
--- a/neutron-openvswitch-cplane/hooks/cplane_interface.py
+++ b/neutron-openvswitch-cplane/hooks/cplane_interface.py
@@ -37,7 +37,9 @@ class UbuntuIntfMgmt(object):
                            intf_save_file=None, read_only=True):
         """ extract the configuration for a specific interface
         """
-        src_file = "/etc/network/interfaces"
+        src_file = "/etc/network/interfaces.d/50-cloud-init.cfg"
+        if not os.path.exists(src_file):
+            src_file = "/etc/network/interfaces"
         back_file = "/tmp/cp_interfaces_file.{dt}".format(
             dt=datetime.now().strftime("%m%d%Y%H%M%S"))
         if backup:


### PR DESCRIPTION
On newer Ubuntu systems, the network configuration file may be generated by
cloud-init and written to /etc/network/interfaces.d/50-cloud-init.cfg

If present, use that, otherwise fallback to reading /etc/network/interfaces.

Note, long term, this code needs to read /etc/network/interfaces, and for each
sourcedir directive in eni, search those directories for additional configurations
to capture all possible network configuration that's under control of ifupdown.